### PR TITLE
Added a reconnect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,15 @@ The url the websocket connection is listening to.
 #### onMessage
 
 **required**
-The callback function that is called when data has been received.
+The callback called when data is received. Data is `JSON.parse`'d
 
 #### debug
 
 default: **false**
 Set to **true** to see console logging
+
+#### reconnect
+
+**optional**
+If set to a number `n` of seconds, will try to re-establish the connection after a random `[0..n]`
+ seconds delay until successful. If unset, there will be no automatic reconnection.

--- a/lib/Websocket.js
+++ b/lib/Websocket.js
@@ -8,7 +8,8 @@ module.exports = React.createClass({
     propTypes: {
         url: React.PropTypes.string.isRequired,
         onMessage: React.PropTypes.func.isRequired,
-        debug: React.PropTypes.bool
+        debug: React.PropTypes.bool,
+	    reconnect: React.PropTypes.number
     },
 
     getDefaultProps: function () {
@@ -29,23 +30,36 @@ module.exports = React.createClass({
         }
     },
 
-    componentWillMount: function () {
-        this.log('Websocket componentWillMount');
-        var self = this;
-        var ws = self.state.ws;
-        ws.addEventListener('open', function open() {
-            self.log('Websocket connected');
-        });
-        ws.addEventListener('message', function incoming(event) {
-            var data = JSON.parse(event.data);
-            self.log('Websocket incoming data');
-            self.log(event.data);
-            self.props.onMessage(data);
-        });
-        ws.addEventListener('close', function close() {
-            self.log('Websocket disconnected');
-        });
-    },
+	_setupSocket: function () {
+		var self = this;
+		var ws = self.state.ws;
+		ws.addEventListener('open', function open() {
+			self.log('Websocket connected');
+		});
+		ws.addEventListener('message', function incoming(event) {
+			var data = JSON.parse(event.data);
+			self.log('Websocket incoming data');
+			self.log(event.data);
+			self.props.onMessage(data);
+		});
+		ws.addEventListener('close', function close() {
+			self.log('Websocket disconnected');
+			if (self.props.reconnect) {
+				var restartDelay = Math.random()*self.props.reconnect;
+				setTimeout(function later() {
+					self.state.ws.close();
+					self.log("Websocket reconnecting");
+					self.setState(self.getInitialState());
+					self._setupSocket();
+				}, restartDelay*1000);
+			}
+		});
+	},
+
+	componentWillMount: function () {
+		this.log('Websocket componentWillMount');
+		this._setupSocket();
+	},
 
     componentWillUnmount: function () {
         this.log('Websocket componentWillUnmount');

--- a/lib/Websocket.js
+++ b/lib/Websocket.js
@@ -44,7 +44,7 @@ module.exports = React.createClass({
         });
         ws.addEventListener('close', function close() {
             self.log('Websocket disconnected');
-            if (self.props.reconnect) {
+            if (self.props.reconnect && !self.preventReconnection) {
                 var restartDelay = Math.random()*self.props.reconnect;
                 setTimeout(function later() {
                     self.state.ws.close();
@@ -58,11 +58,14 @@ module.exports = React.createClass({
 
     componentWillMount: function () {
         this.log('Websocket componentWillMount');
+        this.preventReconnection = false;
         this._setupSocket();
     },
 
     componentWillUnmount: function () {
         this.log('Websocket componentWillUnmount');
+        // we need to prevent reconnection! or we'll set state on an unmounted component
+        this.preventReconnection = true;
         this.state.ws.close();
     },
 

--- a/lib/Websocket.js
+++ b/lib/Websocket.js
@@ -9,7 +9,7 @@ module.exports = React.createClass({
         url: React.PropTypes.string.isRequired,
         onMessage: React.PropTypes.func.isRequired,
         debug: React.PropTypes.bool,
-	    reconnect: React.PropTypes.number
+        reconnect: React.PropTypes.number
     },
 
     getDefaultProps: function () {
@@ -30,36 +30,36 @@ module.exports = React.createClass({
         }
     },
 
-	_setupSocket: function () {
-		var self = this;
-		var ws = self.state.ws;
-		ws.addEventListener('open', function open() {
-			self.log('Websocket connected');
-		});
-		ws.addEventListener('message', function incoming(event) {
-			var data = JSON.parse(event.data);
-			self.log('Websocket incoming data');
-			self.log(event.data);
-			self.props.onMessage(data);
-		});
-		ws.addEventListener('close', function close() {
-			self.log('Websocket disconnected');
-			if (self.props.reconnect) {
-				var restartDelay = Math.random()*self.props.reconnect;
-				setTimeout(function later() {
-					self.state.ws.close();
-					self.log("Websocket reconnecting");
-					self.setState(self.getInitialState());
-					self._setupSocket();
-				}, restartDelay*1000);
-			}
-		});
-	},
+    _setupSocket: function () {
+        var self = this;
+        var ws = self.state.ws;
+        ws.addEventListener('open', function open() {
+            self.log('Websocket connected');
+        });
+        ws.addEventListener('message', function incoming(event) {
+            var data = JSON.parse(event.data);
+            self.log('Websocket incoming data');
+            self.log(event.data);
+            self.props.onMessage(data);
+        });
+        ws.addEventListener('close', function close() {
+            self.log('Websocket disconnected');
+            if (self.props.reconnect) {
+                var restartDelay = Math.random()*self.props.reconnect;
+                setTimeout(function later() {
+                    self.state.ws.close();
+                    self.log("Websocket reconnecting");
+                    self.setState(self.getInitialState());
+                    self._setupSocket();
+                }, restartDelay*1000);
+            }
+        });
+    },
 
-	componentWillMount: function () {
-		this.log('Websocket componentWillMount');
-		this._setupSocket();
-	},
+    componentWillMount: function () {
+        this.log('Websocket componentWillMount');
+        this._setupSocket();
+    },
 
     componentWillUnmount: function () {
         this.log('Websocket componentWillUnmount');

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "homepage": "https://github.com/Sedus/react-websocket",
   "dependencies": {
-    "ws": "^0.7.2"
+    "ws": "^1.0.1"
   }
 }


### PR DESCRIPTION
Hi ! I've added a "reconnect" option to the Websocket component.

How it's used :
`<Websocket reconnect={10} debug={true} url='ws://localhost:8080/' onMessage={this.handleData}/>`

If disconnected, the component will wait between 0 and `10` seconds before attempting a reconnection. The randomness avoids a storm of reconnections in case of server restart.

I've tried using `ws.resume()` instead of recreating the websocket entirely but it fails to work sometimes. Recreating the ws from scratch shows no ill effect.

If reconnection fails, it will attempt a new reconnection later, and so on...

I tried to stick to your code conventions...
