### PR TITLE
Add support for partial JSON messages from the server.

### DIFF
--- a/lib/Websocket.js
+++ b/lib/Websocket.js
@@ -19,7 +19,8 @@ module.exports = React.createClass({
 
     getInitialState: function () {
         return {
-            ws: new WebSocket(this.props.url)
+            ws: new WebSocket(this.props.url),
+            partial: ''
         }
     },
 
@@ -33,14 +34,23 @@ module.exports = React.createClass({
         this.log('Websocket componentWillMount');
         var self = this;
         var ws = self.state.ws;
+        var partial = self.state.partial;
         ws.addEventListener('open', function open() {
             self.log('Websocket connected');
         });
         ws.addEventListener('message', function incoming(event) {
-            var data = JSON.parse(event.data);
-            self.log('Websocket incoming data');
-            self.log(event.data);
-            self.props.onMessage(data);
+            try {
+                var data = JSON.parse(partial + event.data);
+                self.log('Websocket incoming data');
+                self.log(partial + event.data);
+                partial = '';
+                self.setState({partial:partial});
+                self.props.onMessage(data);
+            } catch (err) {
+                partial += event.data;
+                self.log('Websocket storing partial');
+                self.setState({partial:partial});
+            }
         });
         ws.addEventListener('close', function close() {
             self.log('Websocket disconnected');


### PR DESCRIPTION
I was getting JSON fragments in the message event callback so the JSON.parse() was failing. By storing the partial in state, I eventually get a good parse.
