### PR TITLE
Clear timeout on component unmount

### DIFF
--- a/index.jsx
+++ b/index.jsx
@@ -40,7 +40,7 @@ class Websocket extends React.Component {
         this.logging('Websocket disconnected');
         if (this.shouldReconnect) {
           let time = this.generateInterval(this.state.attempts);
-          setTimeout(() => {
+          this.timeoutID = setTimeout(() => {
             this.setState({attempts: this.state.attempts+1});
             this.setState({ws: new WebSocket(this.props.url, this.props.protocol)});
             this.setupWebsocket();
@@ -55,6 +55,7 @@ class Websocket extends React.Component {
 
     componentWillUnmount() {
       this.shouldReconnect = false;
+      clearTimeout(this.timeoutID);
       let websocket = this.state.ws;
       websocket.close();
     }


### PR DESCRIPTION
This fixes the below warning due to timeout not being cleared after component is unmounted.

`setState(...): Can only update a mounted or mounting component. This usually means you called setState() on an unmounted component. This is a no-op. Please check the code for the Websocket component.`