### PR TITLE
Fix onClose documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The callback called when data is received. Data is `JSON.parse`'d
 
 The callback called when the connection is successfully opened.
 
-#### onOpen
+#### onClose
 
 The callback called when the connection is closed either due to server disconnect or network error.
 


### PR DESCRIPTION
onOpen was documented twice, but the second instance has actually the documentation for onClose